### PR TITLE
Make /tp command gps compatible

### DIFF
--- a/commands.lua
+++ b/commands.lua
@@ -878,7 +878,7 @@ script.on_load(
               --Find x/y from argument
               --Matches two potentially negative numbers separated by a comma, gps compatible
               --str could be "-353,19" or "[gps=80,-20]" or "[gps=5,3,hell]"
-              xpos, ypos = str:match("([%-%d]+),([%-%d]+)")
+              xpos, ypos = str:match("(%-?%d+),(%-?%d+)")
               if tonumber(xpos) and tonumber(ypos) then
                 local position = {x = xpos, y = ypos}
 

--- a/commands.lua
+++ b/commands.lua
@@ -876,6 +876,8 @@ script.on_load(
               end
 
               --Find x/y from argument
+              --Matches two potentially negative numbers separated by a comma, gps compatible
+              --str could be "-353,19" or "[gps=80,-20]" or "[gps=5,3,hell]"
               xpos, ypos = str:match("([%-%d]+),([%-%d]+)")
               if tonumber(xpos) and tonumber(ypos) then
                 local position = {x = xpos, y = ypos}

--- a/commands.lua
+++ b/commands.lua
@@ -876,7 +876,7 @@ script.on_load(
               end
 
               --Find x/y from argument
-              xpos, ypos = str:match("([^,]+),([^,]+)")
+              xpos, ypos = str:match("([%-%d]+),([%-%d]+)")
               if tonumber(xpos) and tonumber(ypos) then
                 local position = {x = xpos, y = ypos}
 


### PR DESCRIPTION
This changes the argument parsing of the `/tp` command. Rather than grabbing groups of characters that are not a comma, it grabs groups of numbers that optionally start with a negative sign.

The change is from
* `xpos, ypos = str:match("([^,]+),([^,]+)")` to
* `xpos, ypos = str:match("(%-?%d+),(%-?%d+)")"`

The escape sequences used are as follows.
* `%-` escapes the the negative sign, which is only matched as an optional first character
* `%d+` matches one or more consecutive digits

https://www.lua.org/manual/5.3/manual.html#6.4.1

This allows us to parse the coordinates out of a string like `"[gps=-681,-154]"` just fine. The gps could string could optionally include a third surface term `"[gps=10,5,hell]"`, but that is not handled here since the main use is to grab gps from control-alt-click.

Importantly, this continues to parse strings like `"3,-5"` as well.

Closes #51 