### PR TITLE
Ignore rock/tree deconstruct events

### DIFF
--- a/log.lua
+++ b/log.lua
@@ -246,6 +246,21 @@ function LOG_Decon(event)
         if player and area and area.left_top then
             local decon_size = UTIL_Distance(area.left_top, area.right_bottom)
 
+            -- Ignore if only rocks or trees are selected for deconstruction
+            local only_trees_rocks = true
+            for _, ent in pairs(surface.find_entities_filtered { area = area }) do
+                if ent.valid then
+                    local name = ent.name or ""
+                    if not string.find(name, "tree") and not string.find(name, "rock") then
+                        only_trees_rocks = false
+                        break
+                    end
+                end
+            end
+            if only_trees_rocks then
+                return
+            end
+
             -- Don't bother if selection is zero.
             if decon_size >= 1 then
                 local msg = ""
@@ -317,6 +332,10 @@ function LOG_MarkDecon(event)
         local obj = event.entity
 
         if player then
+            local name = obj and obj.name or ""
+            if string.find(name, "tree") or string.find(name, "rock") then
+                return
+            end
             local msg = "[ACT] " .. player.name .. " decon " .. obj.name .. " at " .. UTIL_GPSObj(obj)
 
             if UTIL_Is_New(player) or UTIL_Is_Member(player) then -- Dont bother with regulars/moderators


### PR DESCRIPTION
## Summary
- avoid logging deconstruction planner events when only rocks or trees are selected
- skip single deconstruction logging for objects with `rock` or `tree` in their name

## Testing
- `luac -p log.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c24c26bc832abe8654c50f94ae80