### PR TITLE
Fix vote table insert index

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,12 @@
+std = "lua51"
+
+-- Globals provided by Factorio
+globals = {
+  "game",
+  "script",
+  "commands",
+  "defines",
+  "remote",
+  "rendering",
+  "storage"
+}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 ### LUA scripts for M45's Factorio servers. ( softmod / scenario scripts )
 <br>Currently approximately 3700 lines of lua.
 <br>
+This mod keeps all persistent state in a global table named `storage`. See
+[`docs/storage.md`](docs/storage.md) for an overview of its layout. A basic
+`luacheck` configuration is provided for optional linting:
+
+```bash
+luacheck *.lua
+```
+
 *banish.lua*<br>
 Allows regulars to vote-ban players,<br>
 <br>

--- a/banish.lua
+++ b/banish.lua
@@ -385,7 +385,9 @@ function BANISH_DoBanish(player, victim, reason)
                                 UTIL_SmartPrint(player, "You have used " .. votecount .. " of your 5 available votes.")
                             end
 
-                            table.insert(storage.SM_Store.votes, 0, {
+                            -- Insert newest vote at the start of the list
+                            -- index 1 is the first valid position in Lua
+                            table.insert(storage.SM_Store.votes, 1, {
                                 voter = player,
                                 victim = victim,
                                 reason = reason,

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,20 @@
+# Storage Table Overview
+
+The mod uses a single global table named `storage` to keep persistent data for all systems.
+This is required because Factorio scenario scripts have limited options for storing global
+state.
+
+`storage` has two main sections:
+
+* `storage.SM_Store` – global mod settings and shared state.
+* `storage.PData` – per-player data indexed by `player.index`.
+
+Each system stores its values in these tables rather than creating additional globals.
+The structure is created during on_init by `STORAGE_CreateGlobal()` and
+`STORAGE_MakePlayerStorage()` in `storage.lua`.
+
+When adding new fields, try to group them logically under these tables. For example,
+`storage.SM_Store.votes` holds active vote-banish information and
+`storage.PData[player.index].active` tracks whether a player was active this tick.
+Keeping related values together helps avoid conflicts and makes saved data easier to
+inspect.


### PR DESCRIPTION
## Summary
- prevent runtime error in banish module by inserting votes at position 1

## Testing
- `luacheck *.lua`


------
https://chatgpt.com/codex/tasks/task_e_684607b96938832a9ff98cfcc3a57813