### PR TITLE
Improve storage docs and inline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 <br>Currently approximately 3700 lines of lua.
 <br>
 This mod keeps all persistent state in a global table named `storage`. See
-[`docs/storage.md`](docs/storage.md) for an overview of its layout. A basic
+[`docs/storage.md`](docs/storage.md) for an overview of its layout and per-module fields.
+When adding new storage keys, update that document and include a comment near the
+code that creates or modifies the key. A basic
 `luacheck` configuration is provided for optional linting:
 
 ```bash

--- a/banish.lua
+++ b/banish.lua
@@ -8,6 +8,7 @@ local function unbanishPlayer(victim)
         return
     end
 
+    -- sendToSurface queue is processed each tick to teleport players
     table.insert(storage.SM_Store.sendToSurface, {
         victim = victim,
         surface = 1,
@@ -18,6 +19,7 @@ local function unbanishPlayer(victim)
         UTIL_MsgAll(victim.name .. " moved out of jailed group.")
     end
 
+    -- mark player as unbanished
     storage.PData[victim.index].banished = 0
     storage.SM_Store.jailGroup.remove_player(victim)
     storage.SM_Store.defGroup.add_player(victim)
@@ -272,6 +274,7 @@ function BANISH_DoJail(victim)
         "'s inventory has been dumped at spawn so the items can be recovered.")
 
     local newpos = game.surfaces["jail"].find_non_colliding_position("character", { x = 0, y = 0 }, 1024, 1, false)
+    -- queue teleport to the jail surface
     table.insert(storage.SM_Store.sendToSurface, {
         victim = victim,
         surface = "jail",
@@ -387,6 +390,7 @@ function BANISH_DoBanish(player, victim, reason)
 
                             -- Insert newest vote at the start of the list
                             -- index 1 is the first valid position in Lua
+                            -- votes table tracks active banishment votes
                             table.insert(storage.SM_Store.votes, 1, {
                                 voter = player,
                                 victim = victim,
@@ -490,6 +494,7 @@ function BANISH_AddBanishCommands()
                         UTIL_SmartPrint(player, "You can't put yourself in jail. Go touch grass.")
                         return
                     end
+                    -- 1000 denotes a jailed state waiting for release
                     storage.PData[victim.index].banished = 1000
                     BANISH_DoJail(victim)
                     UTIL_SmartPrint(player, "Jailed player.")

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,20 +1,40 @@
 # Storage Table Overview
 
-The mod uses a single global table named `storage` to keep persistent data for all systems.
-This is required because Factorio scenario scripts have limited options for storing global
-state.
+The mod uses a single global table named `storage` to keep persistent data for all systems. This is required because Factorio scenario scripts have limited options for storing global state.
 
 `storage` has two main sections:
 
 * `storage.SM_Store` – global mod settings and shared state.
 * `storage.PData` – per-player data indexed by `player.index`.
 
-Each system stores its values in these tables rather than creating additional globals.
-The structure is created during on_init by `STORAGE_CreateGlobal()` and
-`STORAGE_MakePlayerStorage()` in `storage.lua`.
+Each system stores its values in these tables rather than creating additional globals. The structure is created during on_init by `STORAGE_CreateGlobal()` and `STORAGE_MakePlayerStorage()` in `storage.lua`.
 
-When adding new fields, try to group them logically under these tables. For example,
-`storage.SM_Store.votes` holds active vote-banish information and
-`storage.PData[player.index].active` tracks whether a player was active this tick.
-Keeping related values together helps avoid conflicts and makes saved data easier to
-inspect.
+When adding new fields, try to group them logically under these tables. For example, `storage.SM_Store.votes` holds active vote-banish information and `storage.PData[player.index].active` tracks whether a player was active this tick. Keeping related values together helps avoid conflicts and makes saved data easier to inspect.
+
+## Module Storage Fields
+
+### banish.lua
+- `storage.SM_Store.votes` – list of active vote records `{voter, victim, reason, tick, withdrawn, overruled}`.
+- `storage.SM_Store.sendToSurface` – queue for teleporting players after banish/unbanish.
+- `storage.PData[index].banished` – non-zero when a player is jailed or banished.
+- `storage.PData[index].reports` – count of `/report` uses by the player.
+
+### quickbar.lua
+- `storage.PData[index].qb_import_string` – quickbar configuration text awaiting import.
+
+### stash.lua
+- `storage.PData[index].gun_stash` – temporary inventory for guns.
+- `storage.PData[index].ammo_stash` – temporary inventory for ammo.
+- `storage.PData[index].armor_stash` – temporary inventory for armor.
+- `storage.PData[index].armor_equipment_data` – saved equipment grid data when armor is stashed.
+
+### online.lua
+- `storage.SM_Store.pcount` and `storage.SM_Store.tcount` – online and total player counts.
+- `storage.SM_Store.playerList` – cached table of player info for the online window.
+- `storage.PData[index].onlineSub` – name of the player selected in the online submenu.
+- `storage.PData[index].onlineBrief` – whether the brief view is enabled.
+- `storage.PData[index].onlineShowOffline` – whether offline players are shown.
+
+### onelife.lua
+- `storage.SM_Store.oneLifeMode` – global flag enabling permadeath.
+- `storage.PData[index].permDeath` – tracks confirm prompts before deleting a character.

--- a/quickbar.lua
+++ b/quickbar.lua
@@ -244,6 +244,7 @@ function QUICKBAR_Clicks(event)
                 QUICKBAR_MakeExchangeWindow(player, true)
             elseif event.element.name == "import_qb" and player.gui and player.gui.screen then
                 if storage.PData and storage.PData[player.index] and
+                    -- qb_import_string holds a raw quickbar string from the player
                     storage.PData[event.player_index].qb_import_string then
                     ImportQuickbar(player, storage.PData[event.player_index].qb_import_string)
                     QUICKBAR_ClearString(player)
@@ -263,6 +264,7 @@ function QUICKBAR_ClearString(player)
     end
     if storage.PData and storage.PData[player.index] and
         storage.PData[player.index].qb_import_string then
+        -- reset stored quickbar string after processing
         storage.PData[player.index].qb_import_string = ""
     end
 end
@@ -279,6 +281,7 @@ function QUICKBAR_TextChanged(event)
                     event.element.text = "String too long."
                     return
                 end
+                -- Store the text so it can be imported after the GUI closes
                 storage.PData[event.player_index].qb_import_string = event.element.text
             end
         end

--- a/stash.lua
+++ b/stash.lua
@@ -24,6 +24,7 @@ local function ensure_empty_stash(player_index, stash_name, size)
             return true
         end
     else
+        -- create a temporary inventory to hold the player's stashed items
         storage.PData[player_index][stash_name] = game.create_inventory(size)
         return true
     end
@@ -114,8 +115,10 @@ local function stash_armor(player)
                         energy = eq.energy
                     })
                 end
+                -- remember equipment grid so we can restore it when unstashed
                 storage.PData[player.index].armor_equipment_data = equipment_data
             else
+                -- clear any previous grid data if no armor is present
                 storage.PData[player.index].armor_equipment_data = nil
             end
 
@@ -178,6 +181,7 @@ local function unstash_armor(player)
                                 end
                             end
                         end
+                        -- remove stored grid data once restored
                         storage.PData[player.index].armor_equipment_data = nil
                     end
                 else
@@ -235,6 +239,7 @@ function STASH_AddStashCommands()
             if not storage.PData then storage.PData = {} end
             if not storage.PData[player.index] then storage.PData[player.index] = {} end
 
+            -- gun_stash/ammo_stash/armor_stash hold items while stashed
             local can_stash_guns = ensure_empty_stash(player.index, "gun_stash", 3)
             local can_stash_ammo = ensure_empty_stash(player.index, "ammo_stash", 3)
             local can_stash_armor = ensure_empty_stash(player.index, "armor_stash", 1)


### PR DESCRIPTION
## Summary
- document per-module storage fields in `docs/storage.md`
- reference the new documentation in `README.md`
- annotate storage key usage in `banish.lua`, `quickbar.lua` and `stash.lua`

## Testing
- `luacheck *.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461e0db4ac832a9da6fbdf7f551390