### PR TITLE
Fix English locale keys

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -13,7 +13,7 @@ info_tab_patreon=[item=production-science-pack] Patreon
 info_get_qr=Get QR Code
 copy_tooltip=COPY: Click text then Control-C
 
--- todo strings
+; todo strings
 todo_window_title=To-Do List:
 todo_show_hidden=Show hidden
 todo_show_hidden_tooltip=Toggle show hidden notes.

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -14,30 +14,30 @@ info_get_qr=Get QR Code
 copy_tooltip=COPY: Click text then Control-C
 
 -- todo strings
- todo_window_title=To-Do List:
- todo_show_hidden=Show hidden
- todo_show_hidden_tooltip=Toggle show hidden notes.
- todo_button_tooltip=Read or edit the To-Do list.
- todo_submenu_close_tooltip=Close this window
- todo_priority_label=[font=default-large-bold]Priority: [/font]
- todo_subject_label=[font=default-large-bold]Subject: [/font]
- todo_protected_label=Protected
- todo_protected_tooltip=Toggles if other players can edit your todo item.
- todo_edit_warning=CURRENTLY BEING EDITED BY: %s
- todo_unhide=Unhide
- todo_hide=Hide
- todo_save=Save
- todo_view_tooltip=View this item
- todo_edit_tooltip=Edit this item
- todo_move_up_tooltip=move up
- todo_move_down_tooltip=move down
- todo_add_item=Add item
- todo_first_item=It is already the first item!
- todo_last_item=It is already at the end of the list.
- todo_make_throttle=(SYSTEM) Please wait 5 seconds before attempting to make a new item.
- todo_limit_reached=You have personally created 25 todo items, limit reached.
- todo_changes_throttle=(SYSTEM) CHANGES NOT SAVED, PLEASE WAIT 5 SECONDS BEFORE TRYING TO SAVE AGAIN.
- todo_save_error=Sorry, something went wrong, unable to save. Please report this issue.
- todo_delete_error=Sorry, something went wrong, unable to delete. Please report this issue.
- todo_id_error=Error: Could not find note id: %s
- todo_no_changes=No changes to save.
+todo_window_title=To-Do List:
+todo_show_hidden=Show hidden
+todo_show_hidden_tooltip=Toggle show hidden notes.
+todo_button_tooltip=Read or edit the To-Do list.
+todo_submenu_close_tooltip=Close this window
+todo_priority_label=[font=default-large-bold]Priority: [/font]
+todo_subject_label=[font=default-large-bold]Subject: [/font]
+todo_protected_label=Protected
+todo_protected_tooltip=Toggles if other players can edit your todo item.
+todo_edit_warning=CURRENTLY BEING EDITED BY: %s
+todo_unhide=Unhide
+todo_hide=Hide
+todo_save=Save
+todo_view_tooltip=View this item
+todo_edit_tooltip=Edit this item
+todo_move_up_tooltip=move up
+todo_move_down_tooltip=move down
+todo_add_item=Add item
+todo_first_item=It is already the first item!
+todo_last_item=It is already at the end of the list.
+todo_make_throttle=(SYSTEM) Please wait 5 seconds before attempting to make a new item.
+todo_limit_reached=You have personally created 25 todo items, limit reached.
+todo_changes_throttle=(SYSTEM) CHANGES NOT SAVED, PLEASE WAIT 5 SECONDS BEFORE TRYING TO SAVE AGAIN.
+todo_save_error=Sorry, something went wrong, unable to save. Please report this issue.
+todo_delete_error=Sorry, something went wrong, unable to delete. Please report this issue.
+todo_id_error=Error: Could not find note id: %s
+todo_no_changes=No changes to save.


### PR DESCRIPTION
## Summary
- remove accidental leading spaces from `locale/en/locale.cfg`

## Testing
- `luacheck *.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463886b680832abb01865b1c921c27