### PR TITLE
Add translations for score and rules tabs

### DIFF
--- a/info.lua
+++ b/info.lua
@@ -504,8 +504,12 @@ function INFO_InfoWin(player)
             tab2_main_frame.add {
                 type = "label",
                 name = "tab2_score",
-                caption = "[color=orange][font=default-large-bold]Your current score: " ..
-                    math.floor(storage.PData[player.index].score / 60 / 60) .. "[/font][/color]"
+                caption = {
+                    "",
+                    "[color=orange][font=default-large-bold]",
+                    {"strings.info_score_current", math.floor(storage.PData[player.index].score / 60 / 60)},
+                    "[/font][/color]"
+                }
             }
             tab2_main_frame.add {
                 type = "label",
@@ -513,15 +517,15 @@ function INFO_InfoWin(player)
             }
             tab2_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]Membership is automatic & free, and based on score. Your current score is listed above.[/font]"
+                caption = {"", "[font=default-large-bold]", {"strings.info_score_auto"}, "[/font]"}
             }
             tab2_main_frame.add {
                 type = "label",
-                caption = "[font=default-large]The score is specific to this map, and does not carry over to other maps.[/font]"
+                caption = {"", "[font=default-large]", {"strings.info_score_specific"}, "[/font]"}
             }
             tab2_main_frame.add {
                 type = "label",
-                caption = "[font=default-large]Once you achieve a level, the level persists between maps (but the activity score does not).[/font]"
+                caption = {"", "[font=default-large]", {"strings.info_score_persistent"}, "[/font]"}
             }
             tab2_main_frame.add {
                 type = "label",
@@ -534,12 +538,12 @@ function INFO_InfoWin(player)
             if UTIL_Is_New(player) then
                 tab2_main_frame.add {
                     type = "label",
-                    caption = "[recipe=burner-inserter]   [font=default-large-bold][color=red]Level 1: New[/color][/font]"
+                    caption = {"", "[recipe=burner-inserter]   [font=default-large-bold][color=red]", {"strings.info_score_level1"}, "[/color][/font]"}
                 }
             else
                 tab2_main_frame.add {
                     type = "label",
-                    caption = "[recipe=burner-inserter]   [font=default-large-bold]Level 1: New[/font]"
+                    caption = {"", "[recipe=burner-inserter]   [font=default-large-bold]", {"strings.info_score_level1"}, "[/font]"}
                 }
             end
             tab2_main_frame.add {
@@ -549,11 +553,11 @@ function INFO_InfoWin(player)
 
             tab2_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]New players start with limited permissions.[/font]"
+                caption = {"", "[font=default-large-bold]", {"strings.info_score_new_perm"}, "[/font]"}
             }
             tab2_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]Regulars (Level 3+) can BANISH you with one vote.[/font]"
+                caption = {"", "[font=default-large-bold]", {"strings.info_score_new_vote"}, "[/font]"}
             }
             tab2_main_frame.add {
                 type = "label",
@@ -567,12 +571,12 @@ function INFO_InfoWin(player)
             if UTIL_Is_Member(player) then
                 tab2_main_frame.add {
                     type = "label",
-                    caption = "[recipe=inserter]   [font=default-large-bold][color=red]Level 2: Members[/color] (Score: 30)[/font]"
+                    caption = {"", "[recipe=inserter]   [font=default-large-bold][color=red]", {"strings.info_score_level2"}, "[/color][/font]"}
                 }
             else
                 tab2_main_frame.add {
                     type = "label",
-                    caption = "[recipe=inserter]   [font=default-large-bold]Level 2: Members (Score: 30)[/font]"
+                    caption = {"", "[recipe=inserter]   [font=default-large-bold]", {"strings.info_score_level2"}, "[/font]"}
                 }
             end
             tab2_main_frame.add {
@@ -581,15 +585,15 @@ function INFO_InfoWin(player)
             }
             tab2_main_frame.add {
                 type = "label",
-                caption = "[font=default-large]All restrictions lifted.[/font]"
+                caption = {"", "[font=default-large]", {"strings.info_score_l2_lift"}, "[/font]"}
             }
             tab2_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]Deconstruction planner unlocked (with warning).[/font]"
+                caption = {"", "[font=default-large-bold]", {"strings.info_score_l2_decon"}, "[/font]"}
             }
             tab2_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold][color=green]Join our members-only servers.[/color][/font]"
+                caption = {"", "[font=default-large-bold][color=green]", {"strings.info_score_l2_join"}, "[/color][/font]"}
             }
             tab2_main_frame.add {
                 type = "label",
@@ -603,12 +607,12 @@ function INFO_InfoWin(player)
             if UTIL_Is_Regular(player) then
                 tab2_main_frame.add {
                     type = "label",
-                    caption = "[recipe=fast-inserter]   [font=default-large-bold][color=red]Level 3: Regulars[/color] (Score: 240)[/font]"
+                    caption = {"", "[recipe=fast-inserter]   [font=default-large-bold][color=red]", {"strings.info_score_level3"}, "[/color][/font]"}
                 }
             else
                 tab2_main_frame.add {
                     type = "label",
-                    caption = "[recipe=fast-inserter]   [font=default-large-bold]Level 3: Regulars (Score: 240)[/font]"
+                    caption = {"", "[recipe=fast-inserter]   [font=default-large-bold]", {"strings.info_score_level3"}, "[/font]"}
                 }
             end
             tab2_main_frame.add {
@@ -617,15 +621,15 @@ function INFO_InfoWin(player)
             }
             tab2_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]You can BANISH others, and it now takes two votes to banish you.[/font]"
+                caption = {"", "[font=default-large-bold]", {"strings.info_score_l3_banish"}, "[/font]"}
             }
             tab2_main_frame.add {
                 type = "label",
-                caption = "[font=default-large]No more deconstruction planner warnings.[/font]"
+                caption = {"", "[font=default-large]", {"strings.info_score_l3_decon"}, "[/font]"}
             }
             tab2_main_frame.add {
                 type = "label",
-                caption = "[font=default-large]Unlock !vote-map on Discord (after registration).[/font]"
+                caption = {"", "[font=default-large]", {"strings.info_score_l3_vote"}, "[/font]"}
             }
             tab2_main_frame.add {
                 type = "label",
@@ -638,12 +642,12 @@ function INFO_InfoWin(player)
             if UTIL_Is_Veteran(player) then
                 tab2_main_frame.add {
                     type = "label",
-                    caption = "[recipe=stack-inserter]   [font=default-large-bold][color=red]Level 4: Veteran[/color][/font]"
+                    caption = {"", "[recipe=stack-inserter]   [font=default-large-bold][color=red]", {"strings.info_score_level4"}, "[/color][/font]"}
                 }
             else
                 tab2_main_frame.add {
                     type = "label",
-                    caption = "[recipe=stack-inserter]   [font=default-large-bold]Level 4: Veteran[/font] "
+                    caption = {"", "[recipe=stack-inserter]   [font=default-large-bold]", {"strings.info_score_level4"}, "[/font] "}
                 }
             end
             tab2_main_frame.add {
@@ -652,11 +656,11 @@ function INFO_InfoWin(player)
             }
             tab2_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]Veteran status: takes four votes to BANISH you.[/font]"
+                caption = {"", "[font=default-large-bold]", {"strings.info_score_l4_banish"}, "[/font]"}
             }
             tab2_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]Your vote counts double.[/font]"
+                caption = {"", "[font=default-large-bold]", {"strings.info_score_l4_vote"}, "[/font]"}
             }
             tab2_main_frame.add {
                 type = "label",
@@ -692,7 +696,7 @@ function INFO_InfoWin(player)
             tab3_main_frame.style.horizontally_stretchable = true
             tab3_main_frame.add {
                 type = "label",
-                caption = "[item=rail-signal] [font=default-large-bold]Server Rules - Break them and the [entity=behemoth-biter] gets you![/font]"
+                caption = {"", "[item=rail-signal] [font=default-large-bold]", {"strings.info_rules_header"}, "[/font]"}
             }
             tab3_main_frame.add {
                 type = "label",
@@ -700,7 +704,7 @@ function INFO_InfoWin(player)
             }
             tab3_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]1: [recipe=cluster-grenade] Don't be a jerk. Use common sense.[/font]"
+                caption = {"", "[font=default-large-bold]1: [recipe=cluster-grenade] ", {"strings.info_rule1"}, "[/font]"}
             }
             tab3_main_frame.add {
                 type = "label",
@@ -708,7 +712,7 @@ function INFO_InfoWin(player)
             }
             tab3_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]2: [item=programmable-speaker] Don't bug the mods. Try /banish or #moderation-help.[/font]"
+                caption = {"", "[font=default-large-bold]2: [item=programmable-speaker] ", {"strings.info_rule2"}, "[/font]"}
             }
             tab3_main_frame.add {
                 type = "label",
@@ -716,7 +720,7 @@ function INFO_InfoWin(player)
             }
             tab3_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]3: [virtual-signal=signal-everything] No ads or self-promo. Keep crypto and invites elsewhere.[/font]"
+                caption = {"", "[font=default-large-bold]3: [virtual-signal=signal-everything] ", {"strings.info_rule3"}, "[/font]"}
             }
             tab3_main_frame.add {
                 type = "label",
@@ -724,7 +728,7 @@ function INFO_InfoWin(player)
             }
             tab3_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]4: [item=repair-pack] Player problem? Use [font=default-game]BANISH[/font] first.[/font]"
+                caption = {"", "[font=default-large-bold]4: [item=repair-pack] ", {"strings.info_rule4"}, "[/font]"}
             }
             tab3_main_frame.add {
                 type = "label",
@@ -732,7 +736,7 @@ function INFO_InfoWin(player)
             }
             tab3_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]5: [fluid=steam] Not your private server. Compromise or play single player.[/font]"
+                caption = {"", "[font=default-large-bold]5: [fluid=steam] ", {"strings.info_rule5"}, "[/font]"}
             }
             tab3_main_frame.add {
                 type = "label",
@@ -740,7 +744,7 @@ function INFO_InfoWin(player)
             }
             tab3_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]6: [item=radar] Nothing here is private. Public server rules apply.[/font]"
+                caption = {"", "[font=default-large-bold]6: [item=radar] ", {"strings.info_rule6"}, "[/font]"}
             }
             tab3_main_frame.add {
                 type = "label",
@@ -748,7 +752,7 @@ function INFO_InfoWin(player)
             }
             tab3_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]7: [item=blueprint-book] Read the info tabs and help channel before asking.[/font]"
+                caption = {"", "[font=default-large-bold]7: [item=blueprint-book] ", {"strings.info_rule7"}, "[/font]"}
             }
             tab3_main_frame.add {
                 type = "label",
@@ -756,7 +760,7 @@ function INFO_InfoWin(player)
             }
             tab3_main_frame.add {
                 type = "label",
-                caption = "[font=default-large-bold]8: [item=locomotive] Links: m45sci.xyz, /r/M45Sci, Steam group.[/font]"
+                caption = {"", "[font=default-large-bold]8: [item=locomotive] ", {"strings.info_rule8"}, "[/font]"}
             }
 
             -- Close Button Frame

--- a/locale/de/locale.cfg
+++ b/locale/de/locale.cfg
@@ -54,3 +54,34 @@ todo_save_error=Fehler beim Speichern. Bitte Problem melden.
 todo_delete_error=Fehler beim Löschen. Bitte Problem melden.
 todo_id_error=Fehler: Konnte Notiz mit ID %s nicht finden
 todo_no_changes=Keine Änderungen zum Speichern.
+
+; score tab strings
+info_score_current=Dein aktueller Score (Spielzeit in Stunden): %d
+info_score_auto=Mitgliedschaft ist automatisch und kostenlos und basiert auf dem Score. Dein aktueller Score steht oben.
+info_score_specific=Der Score ist kartenspezifisch und wird nicht auf andere Karten übertragen.
+info_score_persistent=Sobald du ein Level erreichst, bleibt es zwischen Karten bestehen (der Aktivitäts-Score jedoch nicht).
+info_score_level1=Level 1: Neu
+info_score_new_perm=Neue Spieler beginnen mit eingeschränkten Berechtigungen.
+info_score_new_vote=Stammgäste (Level 3+) können dich mit einer Stimme BANISH.
+info_score_level2=Level 2: Mitglieder (Score: 30)
+info_score_l2_lift=Alle Einschränkungen aufgehoben.
+info_score_l2_decon=Deconstruction planner freigeschaltet (mit Warnung).
+info_score_l2_join=Tritt unseren Mitglieder-Servern bei.
+info_score_level3=Level 3: Stammgäste (Score: 240)
+info_score_l3_banish=Du kannst andere BANISH und es sind nun zwei Stimmen nötig, um dich zu BANISH.
+info_score_l3_decon=Keine Warnungen zum Deconstruction planner mehr.
+info_score_l3_vote=!vote-map auf Discord freischalten (nach Registrierung).
+info_score_level4=Level 4: Veteran
+info_score_l4_banish=Veteranenstatus: vier Stimmen nötig, um dich zu BANISH.
+info_score_l4_vote=Deine Stimme zählt doppelt.
+
+; rules tab strings
+info_rules_header=Serverregeln - Bei Verstoß holt dich der [entity=behemoth-biter]!
+info_rule1=Sei kein Idiot. Benutze den gesunden Menschenverstand.
+info_rule2=Nerv die Mods nicht. Probier /banish oder #moderation-help.
+info_rule3=Keine Werbung oder Eigenwerbung. Lass Krypto und Einladungen woanders.
+info_rule4=Spielerproblem? Nutze zuerst BANISH.
+info_rule5=Dies ist nicht dein privater Server. Kompromiss oder Einzelspieler.
+info_rule6=Nichts hier ist privat. Öffentliche Serverregeln gelten.
+info_rule7=Lies die Info-Tabs und den Hilfekanal, bevor du fragst.
+info_rule8=Links: m45sci.xyz, /r/M45Sci, Steam-Gruppe.

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -56,3 +56,34 @@ todo_save_error=Sorry, something went wrong, unable to save. Please report this 
 todo_delete_error=Sorry, something went wrong, unable to delete. Please report this issue.
 todo_id_error=Error: Could not find note id: %s
 todo_no_changes=No changes to save.
+
+; score tab strings
+info_score_current=Your current score: %d
+info_score_auto=Membership is automatic & free, and based on score. Your current score is listed above.
+info_score_specific=The score is specific to this map, and does not carry over to other maps.
+info_score_persistent=Once you achieve a level, the level persists between maps (but the activity score does not).
+info_score_level1=Level 1: New
+info_score_new_perm=New players start with limited permissions.
+info_score_new_vote=Regulars (Level 3+) can BANISH you with one vote.
+info_score_level2=Level 2: Members (Score: 30)
+info_score_l2_lift=All restrictions lifted.
+info_score_l2_decon=Deconstruction planner unlocked (with warning).
+info_score_l2_join=Join our members-only servers.
+info_score_level3=Level 3: Regulars (Score: 240)
+info_score_l3_banish=You can BANISH others, and it now takes two votes to banish you.
+info_score_l3_decon=No more deconstruction planner warnings.
+info_score_l3_vote=Unlock !vote-map on Discord (after registration).
+info_score_level4=Level 4: Veteran
+info_score_l4_banish=Veteran status: takes four votes to BANISH you.
+info_score_l4_vote=Your vote counts double.
+
+; rules tab strings
+info_rules_header=Server Rules - Break them and the [entity=behemoth-biter] gets you!
+info_rule1=Don't be a jerk. Use common sense.
+info_rule2=Don't bug the mods. Try /banish or #moderation-help.
+info_rule3=No ads or self-promo. Keep crypto and invites elsewhere.
+info_rule4=Player problem? Use BANISH first.
+info_rule5=Not your private server. Compromise or play single player.
+info_rule6=Nothing here is private. Public server rules apply.
+info_rule7=Read the info tabs and help channel before asking.
+info_rule8=Links: m45sci.xyz, /r/M45Sci, Steam group.

--- a/locale/es/locale.cfg
+++ b/locale/es/locale.cfg
@@ -55,3 +55,34 @@ todo_save_error=Lo sentimos, ocurrió un error al guardar. Por favor reporta est
 todo_delete_error=Lo sentimos, ocurrió un error al eliminar. Por favor reporta este problema.
 todo_id_error=Error: No se pudo encontrar la nota id: %s
 todo_no_changes=No hay cambios para guardar.
+
+; score tab strings
+info_score_current=Tu puntuación actual (horas jugadas): %d
+info_score_auto=La membresía es automática y gratuita, basada en la puntuación. Tu puntuación actual aparece arriba.
+info_score_specific=La puntuación es específica de este mapa y no se transfiere a otros mapas.
+info_score_persistent=Una vez que logres un nivel, este se mantiene entre mapas (pero la puntuación de actividad no).
+info_score_level1=Nivel 1: Nuevo
+info_score_new_perm=Los jugadores nuevos comienzan con permisos limitados.
+info_score_new_vote=Los regulares (Nivel 3+) pueden usar BANISH contra ti con un solo voto.
+info_score_level2=Nivel 2: Miembros (Puntuación: 30)
+info_score_l2_lift=Todas las restricciones eliminadas.
+info_score_l2_decon=Deconstruction planner desbloqueado (con advertencia).
+info_score_l2_join=Únete a nuestros servidores solo para miembros.
+info_score_level3=Nivel 3: Regulares (Puntuación: 240)
+info_score_l3_banish=Puedes usar BANISH con otros y ahora se requieren dos votos para BANISH contra ti.
+info_score_l3_decon=Ya no hay advertencias del Deconstruction planner.
+info_score_l3_vote=Desbloquea !vote-map en Discord (tras registrarte).
+info_score_level4=Nivel 4: Veterano
+info_score_l4_banish=Estado de veterano: se necesitan cuatro votos para BANISH contra ti.
+info_score_l4_vote=Tu voto cuenta doble.
+
+; rules tab strings
+info_rules_header=Reglas del servidor: ¡si las rompes, el [entity=behemoth-biter] te atrapará!
+info_rule1=No seas idiota. Usa el sentido común.
+info_rule2=No molestes a los moderadores. Prueba /banish o #moderation-help.
+info_rule3=Sin anuncios ni autopromoción. Mantén la cripto y las invitaciones en otro lugar.
+info_rule4=¿Problemas con un jugador? Usa BANISH primero.
+info_rule5=No es tu servidor privado. Llega a un acuerdo o juega en solitario.
+info_rule6=Aquí nada es privado. Se aplican las reglas de servidores públicos.
+info_rule7=Lee las pestañas informativas y el canal de ayuda antes de preguntar.
+info_rule8=Enlaces: m45sci.xyz, /r/M45Sci, grupo de Steam.

--- a/locale/fr/locale.cfg
+++ b/locale/fr/locale.cfg
@@ -55,3 +55,34 @@ todo_save_error=Désolé, une erreur est survenue, impossible d'enregistrer. Veu
 todo_delete_error=Désolé, une erreur est survenue, impossible de supprimer. Veuillez signaler ce problème.
 todo_id_error=Erreur: impossible de trouver l'identifiant de la note: %s
 todo_no_changes=Aucune modification à enregistrer.
+
+; score tab strings
+info_score_current=Votre score actuel (heures jouées) : %d
+info_score_auto=L'adhésion est automatique et gratuite, basée sur le score. Votre score actuel est indiqué ci-dessus.
+info_score_specific=Le score est spécifique à cette carte et ne se transfère pas aux autres cartes.
+info_score_persistent=Une fois un niveau atteint, il persiste entre les cartes (mais pas le score d'activité).
+info_score_level1=Niveau 1 : Nouveau
+info_score_new_perm=Les nouveaux joueurs commencent avec des permissions limitées.
+info_score_new_vote=Les habitués (Niveau 3+) peuvent utiliser BANISH contre vous avec un seul vote.
+info_score_level2=Niveau 2 : Membres (Score : 30)
+info_score_l2_lift=Toutes les restrictions sont levées.
+info_score_l2_decon=Deconstruction planner débloqué (avec avertissement).
+info_score_l2_join=Rejoignez nos serveurs réservés aux membres.
+info_score_level3=Niveau 3 : Habitués (Score : 240)
+info_score_l3_banish=Vous pouvez BANISH les autres et il faut désormais deux votes pour BANISH contre vous.
+info_score_l3_decon=Plus d'avertissements pour le Deconstruction planner.
+info_score_l3_vote=Débloquez !vote-map sur Discord (après inscription).
+info_score_level4=Niveau 4 : Vétéran
+info_score_l4_banish=Statut de vétéran : quatre votes nécessaires pour BANISH contre vous.
+info_score_l4_vote=Votre vote compte double.
+
+; rules tab strings
+info_rules_header=Règles du serveur - Les enfreindre et le [entity=behemoth-biter] vous attrapera !
+info_rule1=Ne soyez pas un idiot. Faites preuve de bon sens.
+info_rule2=Ne harcelez pas les modérateurs. Essayez /banish ou #moderation-help.
+info_rule3=Pas de pub ni d'auto-promotion. Gardez la crypto et les invitations ailleurs.
+info_rule4=Problème avec un joueur ? Utilisez d'abord BANISH.
+info_rule5=Ce n'est pas votre serveur privé. Faites des compromis ou jouez en solo.
+info_rule6=Rien n'est privé ici. Les règles des serveurs publics s'appliquent.
+info_rule7=Lisez les onglets d'information et le canal d'aide avant de poser des questions.
+info_rule8=Liens : m45sci.xyz, /r/M45Sci, groupe Steam.

--- a/locale/it/locale.cfg
+++ b/locale/it/locale.cfg
@@ -55,3 +55,34 @@ todo_save_error=Spiacente, qualcosa è andato storto nel salvataggio. Segnala il
 todo_delete_error=Spiacente, qualcosa è andato storto nell'eliminazione. Segnala il problema.
 todo_id_error=Errore: impossibile trovare nota id: %s
 todo_no_changes=Nessuna modifica da salvare.
+
+; score tab strings
+info_score_current=Il tuo punteggio attuale (ore di gioco): %d
+info_score_auto=L'iscrizione è automatica e gratuita, basata sul punteggio. Il tuo punteggio attuale è indicato sopra.
+info_score_specific=Il punteggio è specifico per questa mappa e non viene trasferito ad altre mappe.
+info_score_persistent=Una volta raggiunto un livello, questo persiste tra le mappe (ma non il punteggio di attività).
+info_score_level1=Livello 1: Nuovo
+info_score_new_perm=I nuovi giocatori iniziano con permessi limitati.
+info_score_new_vote=I regolari (Livello 3+) possono usare BANISH contro di te con un solo voto.
+info_score_level2=Livello 2: Membri (Punteggio: 30)
+info_score_l2_lift=Tutte le restrizioni rimosse.
+info_score_l2_decon=Deconstruction planner sbloccato (con avviso).
+info_score_l2_join=Unisciti ai nostri server riservati ai membri.
+info_score_level3=Livello 3: Regolari (Punteggio: 240)
+info_score_l3_banish=Puoi utilizzare BANISH sugli altri e ora servono due voti per BANISH su di te.
+info_score_l3_decon=Nessun avviso per il Deconstruction planner.
+info_score_l3_vote=Sblocca !vote-map su Discord (dopo la registrazione).
+info_score_level4=Livello 4: Veterano
+info_score_l4_banish=Stato veterano: servono quattro voti per BANISH contro di te.
+info_score_l4_vote=Il tuo voto vale doppio.
+
+; rules tab strings
+info_rules_header=Regole del server - Infrangile e il [entity=behemoth-biter] ti prenderà!
+info_rule1=Non fare l'idiota. Usa il buon senso.
+info_rule2=Non infastidire i moderatori. Prova /banish o #moderation-help.
+info_rule3=Niente pubblicità o autopromozione. Tieni crypto e inviti altrove.
+info_rule4=Problemi con un giocatore? Usa prima BANISH.
+info_rule5=Non è il tuo server privato. Trova un compromesso o gioca in singolo.
+info_rule6=Qui niente è privato. Si applicano le regole dei server pubblici.
+info_rule7=Leggi le schede informative e il canale di aiuto prima di chiedere.
+info_rule8=Link: m45sci.xyz, /r/M45Sci, gruppo Steam.

--- a/locale/pt/locale.cfg
+++ b/locale/pt/locale.cfg
@@ -55,3 +55,34 @@ todo_save_error=Desculpe, algo deu errado ao salvar. Informe o problema.
 todo_delete_error=Desculpe, algo deu errado ao excluir. Informe o problema.
 todo_id_error=Erro: Não foi possível encontrar a nota id: %s
 todo_no_changes=Sem alterações para salvar.
+
+; score tab strings
+info_score_current=Sua pontuação atual (horas jogadas): %d
+info_score_auto=A associação é automática e gratuita, baseada na pontuação. Sua pontuação atual está listada acima.
+info_score_specific=A pontuação é específica deste mapa e não é transferida para outros.
+info_score_persistent=Depois de atingir um nível, ele permanece entre mapas (mas a pontuação de atividade não).
+info_score_level1=Nível 1: Novo
+info_score_new_perm=Novos jogadores começam com permissões limitadas.
+info_score_new_vote=Regulares (Nível 3+) podem usar BANISH contra você com um único voto.
+info_score_level2=Nível 2: Membros (Pontuação: 30)
+info_score_l2_lift=Todas as restrições removidas.
+info_score_l2_decon=Deconstruction planner desbloqueado (com aviso).
+info_score_l2_join=Junte-se aos nossos servidores exclusivos para membros.
+info_score_level3=Nível 3: Regulares (Pontuação: 240)
+info_score_l3_banish=Você pode BANISH outros, e agora são necessários dois votos para BANISH contra você.
+info_score_l3_decon=Sem mais avisos do Deconstruction planner.
+info_score_l3_vote=Desbloqueie !vote-map no Discord (após o registro).
+info_score_level4=Nível 4: Veterano
+info_score_l4_banish=Status de veterano: são necessários quatro votos para BANISH contra você.
+info_score_l4_vote=Seu voto vale por dois.
+
+; rules tab strings
+info_rules_header=Regras do servidor - Quebre-as e o [entity=behemoth-biter] pegará você!
+info_rule1=Não seja idiota. Use o bom senso.
+info_rule2=Não incomode os moderadores. Tente /banish ou #moderation-help.
+info_rule3=Sem anúncios ou autopromoção. Mantenha crypto e convites em outro lugar.
+info_rule4=Problema com jogador? Use BANISH primeiro.
+info_rule5=Não é seu servidor privado. Comprometa-se ou jogue sozinho.
+info_rule6=Nada aqui é privado. Regras de servidores públicos se aplicam.
+info_rule7=Leia as abas de informação e o canal de ajuda antes de perguntar.
+info_rule8=Links: m45sci.xyz, /r/M45Sci, grupo Steam.


### PR DESCRIPTION
## Summary
- translate score and rules info for de, es, fr, it, and pt locales

## Testing
- `luacheck *.lua` *(fails: produces many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6846c1cde414832abc0ec995459f70cb