### PR TITLE
Fix score localization placeholder

### DIFF
--- a/info.lua
+++ b/info.lua
@@ -507,7 +507,7 @@ function INFO_InfoWin(player)
                 caption = {
                     "",
                     "[color=orange][font=default-large-bold]",
-                    {"strings.info_score_current", math.floor(storage.PData[player.index].score / 60 / 60)},
+                    {"strings.info_score_current", tostring(math.floor(storage.PData[player.index].score / 60 / 60))},
                     "[/font][/color]"
                 }
             }


### PR DESCRIPTION
## Summary
- fix `%d` being shown for membership score

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847704eb8e8832a97ea455fe0332457