### PR TITLE
Fix score localization placeholder

### DIFF
--- a/locale/de/locale.cfg
+++ b/locale/de/locale.cfg
@@ -56,7 +56,7 @@ todo_id_error=Fehler: Konnte Notiz mit ID %s nicht finden
 todo_no_changes=Keine Änderungen zum Speichern.
 
 ; score tab strings
-info_score_current=Dein aktueller Score (Spielzeit in Stunden): %d
+info_score_current=Dein aktueller Score (Spielzeit in Stunden): %s
 info_score_auto=Mitgliedschaft ist automatisch und kostenlos und basiert auf dem Score. Dein aktueller Score steht oben.
 info_score_specific=Der Score ist kartenspezifisch und wird nicht auf andere Karten übertragen.
 info_score_persistent=Sobald du ein Level erreichst, bleibt es zwischen Karten bestehen (der Aktivitäts-Score jedoch nicht).

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -58,7 +58,7 @@ todo_id_error=Error: Could not find note id: %s
 todo_no_changes=No changes to save.
 
 ; score tab strings
-info_score_current=Your current score: %d
+info_score_current=Your current score: %s
 info_score_auto=Membership is automatic & free, and based on score. Your current score is listed above.
 info_score_specific=The score is specific to this map, and does not carry over to other maps.
 info_score_persistent=Once you achieve a level, the level persists between maps (but the activity score does not).

--- a/locale/es/locale.cfg
+++ b/locale/es/locale.cfg
@@ -57,7 +57,7 @@ todo_id_error=Error: No se pudo encontrar la nota id: %s
 todo_no_changes=No hay cambios para guardar.
 
 ; score tab strings
-info_score_current=Tu puntuación actual (horas jugadas): %d
+info_score_current=Tu puntuación actual (horas jugadas): %s
 info_score_auto=La membresía es automática y gratuita, basada en la puntuación. Tu puntuación actual aparece arriba.
 info_score_specific=La puntuación es específica de este mapa y no se transfiere a otros mapas.
 info_score_persistent=Una vez que logres un nivel, este se mantiene entre mapas (pero la puntuación de actividad no).

--- a/locale/fr/locale.cfg
+++ b/locale/fr/locale.cfg
@@ -57,7 +57,7 @@ todo_id_error=Erreur: impossible de trouver l'identifiant de la note: %s
 todo_no_changes=Aucune modification à enregistrer.
 
 ; score tab strings
-info_score_current=Votre score actuel (heures jouées) : %d
+info_score_current=Votre score actuel (heures jouées) : %s
 info_score_auto=L'adhésion est automatique et gratuite, basée sur le score. Votre score actuel est indiqué ci-dessus.
 info_score_specific=Le score est spécifique à cette carte et ne se transfère pas aux autres cartes.
 info_score_persistent=Une fois un niveau atteint, il persiste entre les cartes (mais pas le score d'activité).

--- a/locale/it/locale.cfg
+++ b/locale/it/locale.cfg
@@ -57,7 +57,7 @@ todo_id_error=Errore: impossibile trovare nota id: %s
 todo_no_changes=Nessuna modifica da salvare.
 
 ; score tab strings
-info_score_current=Il tuo punteggio attuale (ore di gioco): %d
+info_score_current=Il tuo punteggio attuale (ore di gioco): %s
 info_score_auto=L'iscrizione è automatica e gratuita, basata sul punteggio. Il tuo punteggio attuale è indicato sopra.
 info_score_specific=Il punteggio è specifico per questa mappa e non viene trasferito ad altre mappe.
 info_score_persistent=Una volta raggiunto un livello, questo persiste tra le mappe (ma non il punteggio di attività).

--- a/locale/pt/locale.cfg
+++ b/locale/pt/locale.cfg
@@ -57,7 +57,7 @@ todo_id_error=Erro: Não foi possível encontrar a nota id: %s
 todo_no_changes=Sem alterações para salvar.
 
 ; score tab strings
-info_score_current=Sua pontuação atual (horas jogadas): %d
+info_score_current=Sua pontuação atual (horas jogadas): %s
 info_score_auto=A associação é automática e gratuita, baseada na pontuação. Sua pontuação atual está listada acima.
 info_score_specific=A pontuação é específica deste mapa e não é transferida para outros.
 info_score_persistent=Depois de atingir um nível, ele permanece entre mapas (mas a pontuação de atividade não).


### PR DESCRIPTION
## Summary
- fix `%d` being shown for membership score by updating locale files to use `%s`
- remove unnecessary string conversion in the score label

## Testing
- `luacheck *.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847704eb8e8832a97ea455fe0332457