### PR TITLE
Ignore natural entities for deconstruction logs

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -18,7 +18,7 @@ require "quickbar" -- Save or Restore Quickbar
 require "stash" -- Save or Restore Weapon/Ammo/Armor
 
 function RunSetup()
-    storage.SM_Version = "649-06.09.2025-0544"
+    storage.SM_Version = "650-06.09.2025-0722p"
 
     storage.SM_OldVersion = storage.SM_Version
 

--- a/log.lua
+++ b/log.lua
@@ -247,18 +247,15 @@ function LOG_Decon(event)
         if player and area and area.left_top then
             local decon_size = UTIL_Distance(area.left_top, area.right_bottom)
 
-            -- Ignore if only rocks or trees are selected for deconstruction
-            local only_trees_rocks = true
+            -- Ignore if the selection only contains naturally generated entities
+            local only_natural = true
             for _, ent in pairs(surface.find_entities_filtered { area = area }) do
-                if ent.valid then
-                    local name = ent.name or ""
-                    if not string.find(name, "tree") and not string.find(name, "rock") then
-                        only_trees_rocks = false
-                        break
-                    end
+                if ent.valid and not UTIL_IsNatural(ent) then
+                    only_natural = false
+                    break
                 end
             end
-            if only_trees_rocks then
+            if only_natural then
                 return
             end
 
@@ -333,8 +330,7 @@ function LOG_MarkDecon(event)
         local obj = event.entity
 
         if player then
-            local name = obj and obj.name or ""
-            if string.find(name, "tree") or string.find(name, "rock") then
+            if UTIL_IsNatural(obj) then
                 return
             end
             local msg = "[ACT] " .. player.name .. " decon " .. obj.name .. " at " .. UTIL_GPSObj(obj)

--- a/utility.lua
+++ b/utility.lua
@@ -200,6 +200,18 @@ function UTIL_ConsolePrint(message)
     end
 end
 
+-- Determine if an entity is part of the natural world rather than
+-- something placed by a player. Natural entities generally belong to
+-- the neutral force or have no force at all.
+function UTIL_IsNatural(entity)
+    if entity and entity.valid then
+        if not entity.force or (entity.force and entity.force.name == "neutral") then
+            return true
+        end
+    end
+    return false
+end
+
 -- Smart/safe Print
 function UTIL_SmartPrint(player, message)
     if message then


### PR DESCRIPTION
## Summary
- ignore natural entities when logging deconstruction areas
- add helper `UTIL_IsNatural` to detect neutral force entities

## Testing
- `luacheck *.lua`

------
https://chatgpt.com/codex/tasks/task_e_68477fa00e54832a8a2ec9fd6d6e1fe2